### PR TITLE
Day 20: Trench Map

### DIFF
--- a/src/Grid.kt
+++ b/src/Grid.kt
@@ -5,8 +5,15 @@ typealias GridPosition = Pair<Int, Int>
 class Grid(
     val height: Int,
     val width: Int,
+    val defaultValue: Int = 0
 ) {
-    private val _grid: MutableMap<GridPosition, Point> = mutableMapOf()
+    private val _grid: MutableMap<GridPosition, Point> = mutableMapOf<GridPosition, Point>().also {
+        for (x in (0 until width)) {
+            for (y in (0 until height)) {
+                it[x to y] = Point(x, y, defaultValue)
+            }
+        }
+    }
 
     val allPoints: List<Point>
         get() = _grid.values.toList()
@@ -14,8 +21,8 @@ class Grid(
     fun getPoint(position: GridPosition) =
         _grid[position].let {
             if (it == null) {
-                println("oh dear")
-                throw RuntimeException()
+                this.addPoint(Point(position.first, position.second, defaultValue))
+                _grid[position]!!
             } else {
                 it
             }
@@ -28,6 +35,10 @@ class Grid(
         _grid[point.position] = point
     }
 
+    fun addPoint(x: Int, y: Int, value: Int) {
+        _grid[x to y] = Point(x, y, value)
+    }
+
     fun dump() {
         (0 until height).forEach { y ->
             (0 until width).forEach { x ->
@@ -35,6 +46,9 @@ class Grid(
             }
             println()
         }
+        println("                         ")
+        println("-------------------------")
+        println("                         ")
     }
 
     inner class Point(

--- a/src/day20/Main.kt
+++ b/src/day20/Main.kt
@@ -1,0 +1,69 @@
+package com.zpthacker.aoc21.day20
+
+import com.zpthacker.aoc21.Grid
+import com.zpthacker.aoc21.binaryToDecimal
+import com.zpthacker.aoc21.getInput
+
+fun main() {
+    val input = getInput(20)
+    val (enhancementString, imageString) = input.trim().split("\n\n")
+    val imageLines = imageString.split("\n")
+    val image = Grid(imageLines.count(), imageLines.first().length)
+    imageLines.forEachIndexed { y, line ->
+        line.forEachIndexed { x, ch ->
+            image.addPoint(x, y, if (ch == '#') 1 else 0)
+        }
+    }
+    var currentImage = image
+    repeat(2) {
+        currentImage = enhance(currentImage, enhancementString, it)
+    }
+    println("Part 1: ${currentImage.allPoints.count { it.value == 1 }}")
+    currentImage = image
+    repeat(50) {
+        currentImage = enhance(currentImage, enhancementString, it)
+    }
+    println("Part 2: ${currentImage.allPoints.count { it.value == 1 }}")
+}
+
+fun enhance(image: Grid, enhancementString: String, step: Int): Grid {
+    val referenceGrid = Grid(
+        height = image.height + 4,
+        width = image.width + 4,
+        defaultValue = if (enhancementString[0] == '#') {
+            if (step % 2 == 1) 1 else 0
+        } else {
+            0
+        }
+    )
+    for (point in image.allPoints) {
+        referenceGrid.addPoint(
+            x = point.x+2,
+            y = point.y+2,
+            value = point.value
+        )
+    }
+    val newGrid = Grid(
+        width = referenceGrid.width - 2,
+        height = referenceGrid.height - 2,
+        defaultValue = referenceGrid.defaultValue
+    )
+    for (newPoint in newGrid.allPoints) {
+        val referencePoint = referenceGrid.getPoint((newPoint.x + 1) to (newPoint.y + 1))
+        val neighbors = (referencePoint.allNeighbors + referencePoint).sortedWith { a, b ->
+            if (a.y == b.y) {
+                a.x.compareTo(b.x)
+            } else {
+                a.y.compareTo(b.y)
+            }
+        }
+        val binaryString = neighbors.map(Grid.Point::value).joinToString("")
+        val enhancementPoint = binaryString.binaryToDecimal()
+        newGrid.addPoint(
+            x = newPoint.x,
+            y = newPoint.y,
+            value = if (enhancementString[enhancementPoint] == '#') 1 else 0
+        )
+    }
+    return newGrid
+}


### PR DESCRIPTION
```kotlin
repeat(50) { println("Enhance.") }
```

This was a novel problem. The "trick" was pretty well obscured. Admittedly, I asked around on Reddit for someone's test input/answer so I could more easily test without guess/checking against the website.

Pretty straightforward approach. Each iteration, I build two new grids:

1. Reference grid: grows 2 units outward. I use this to help me find the enhancement index. I insert the old image into this grid (offset by 2 units so it is surrounded on all sides by the default grid value*)
2. Print grid: grows 1 unit outward. This is where the final image is stored

\* The default grid value is weird! If the first char of your enhancement string is `#`, then the default grid value will oscillate because

```
0 0 0
0 0 0
0 0 0
```

will hit that first value, turning the infinite plane into 1s. Then those 3x3 1 grids will turn back into zero.

I look up the neighbors in the reference grid to build the binary enhancement index (by growing it out 2 units, I can cover all the edges of the image when fetching the 3x3 grid that forms the enhancement index), then insert that enhancement value into the print grid.

Anyway, this was a lot of fun! I enjoyed this one despite the weird little quirk with the puzzle input. I understand they didn't want to give the answer away that easily but it would've been nice to have something better to test with.